### PR TITLE
Configure dependabot to send "patch" prefixed commits

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/"
+    update_schedule: "daily"
+    commit_message:
+      prefix: "patch"


### PR DESCRIPTION
This allows versionbot to interpret the PRs as patch type commits.

Fixes product-os/landr#291

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>