### PR TITLE
dwb: remove trailing .git

### DIFF
--- a/lib/components/jumbotron.jsx
+++ b/lib/components/jumbotron.jsx
@@ -84,7 +84,7 @@ export const variants = (metadata, _context, _route, routes) => {
       packageName: metadata.data.name,
       action: `/${entryUrl.path.join('/')}`,
       logoBrandMark: metadata.data.logoBrandMark,
-      deployWithBalenaUrl: metadata.data.deployWithBalenaUrl,
+      deployWithBalenaUrl: metadata.data.deployWithBalenaUrl.replace('.git', ''),
       steps,
       type: metadata.data.type,
       repositoryUrl: metadata.data.links.repository,

--- a/lib/components/setup-and-configuration.jsx
+++ b/lib/components/setup-and-configuration.jsx
@@ -36,7 +36,7 @@ export const variants = (metadata) => {
   if (metadata.data.setup) {
     combinations.push({
       setup: metadata.data.setup,
-      deployWithBalenaUrl: metadata.data.deployWithBalenaUrl
+      deployWithBalenaUrl: metadata.data.deployWithBalenaUrl.replace('.git', '')
     })
   }
 


### PR DESCRIPTION
Looks like metadata extracted by scrutinizer has `.git` on github URLs. This PR removes it if present similar to what's been done in other parts of landr's codebase, for example https://github.com/product-os/landr/blob/730d6c6fc0f377bcf1cab686788820463164a54e/lib/components/doc-viewer.jsx#L46-L49

Resolves: #384
Change-type: patch
Signed-off-by: Tomás Migone <tomas@balena.io>