### PR TITLE
Display download asset name instead of project name

### DIFF
--- a/lib/components/Downloads/index.jsx
+++ b/lib/components/Downloads/index.jsx
@@ -16,7 +16,6 @@
 
 import React from 'react'
 import styled from 'styled-components'
-import capitalize from 'lodash/capitalize'
 import {
   Box,
   Container,
@@ -103,7 +102,7 @@ const Downloads = (props) => {
                     return (
                       <tr key={index}>
                         <td>
-                          {capitalize(props.name)} for {asset.os}{' '}
+                          {asset.name}{' '}
                           {asset.installerType ? (
                             <span>{asset.installerType}</span>
                           ) : null}

--- a/lib/components/Downloads/variants.js
+++ b/lib/components/Downloads/variants.js
@@ -6,10 +6,10 @@ export const variants = (metadata) => {
   const combinations = []
 
   if (
-    !isEmpty(get(metadata, [ 'data', 'releases', 'latestRelease', 'asssets' ]))
+    !isEmpty(get(metadata, [ 'data', 'releases', 'latestRelease', 'assets' ]))
   ) {
     combinations.push({
-      assets: metadata.data.releases.latestRelease.asssets,
+      assets: metadata.data.releases.latestRelease.assets,
       tag: metadata.data.releases.latestRelease.tagName,
       name: metadata.data.name
     })

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -57,7 +57,7 @@
         "replace-string": "^3.0.0",
         "rfdc": "^1.1.4",
         "rimraf": "^2.6.3",
-        "scrutinizer": "^4.11.3",
+        "scrutinizer": "^5.0.0",
         "serialize-error": "^6.0.0",
         "shelljs": "^0.8.4",
         "simple-git": "^3.3.0",
@@ -29809,9 +29809,9 @@
       }
     },
     "node_modules/scrutinizer": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/scrutinizer/-/scrutinizer-4.11.3.tgz",
-      "integrity": "sha512-vpO1DWDVTNCj60QDGOkqbCdIFyEDKwfw5kp4EvPpgDZ2U5h9bZMxhMv85VqzxzvdmW2B33UoL4N1QokKxDDpPg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/scrutinizer/-/scrutinizer-5.0.0.tgz",
+      "integrity": "sha512-PkHEnq4TTsqmNPKz5SN0AK9AxhSOrd+tO7pEmvbuANbAGbh7Dz9YWF3wxfTY9h+D5zXhxdky79CGcyixBcngEQ==",
       "dependencies": {
         "@octokit/rest": "^18.12.0",
         "bluebird": "^3.7.2",
@@ -59706,9 +59706,9 @@
       }
     },
     "scrutinizer": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/scrutinizer/-/scrutinizer-4.11.3.tgz",
-      "integrity": "sha512-vpO1DWDVTNCj60QDGOkqbCdIFyEDKwfw5kp4EvPpgDZ2U5h9bZMxhMv85VqzxzvdmW2B33UoL4N1QokKxDDpPg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/scrutinizer/-/scrutinizer-5.0.0.tgz",
+      "integrity": "sha512-PkHEnq4TTsqmNPKz5SN0AK9AxhSOrd+tO7pEmvbuANbAGbh7Dz9YWF3wxfTY9h+D5zXhxdky79CGcyixBcngEQ==",
       "requires": {
         "@octokit/rest": "^18.12.0",
         "bluebird": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "replace-string": "^3.0.0",
     "rfdc": "^1.1.4",
     "rimraf": "^2.6.3",
-    "scrutinizer": "^4.11.3",
+    "scrutinizer": "^5.0.0",
     "serialize-error": "^6.0.0",
     "shelljs": "^0.8.4",
     "simple-git": "^3.3.0",


### PR DESCRIPTION
- Updates scrutinizer to v5
  - better detect os and arch of a release

Change-type: patch
Signed-off-by: Amit Solanki <amit@balena.io>